### PR TITLE
Fix Buffer initialization to correctly assign node parameter (fixes #3)

### DIFF
--- a/mogi_trajectory_server/trajectory.py
+++ b/mogi_trajectory_server/trajectory.py
@@ -18,7 +18,7 @@ class TrajectoryPublisher(Node):
         self.declare_parameter("min_distance", 0.1) # in meters
 
         # TF2 Listener
-        self.tf_buffer = Buffer(self)
+        self.tf_buffer = Buffer(node=self)
         # Decrease CPU load by not using a TransformListener
         # Using https://github.com/bit-bots/bitbots_tf_buffer instead
         #self.tf_listener = TransformListener(self.tf_buffer, self)


### PR DESCRIPTION
This pull request fixes a TypeError that occurs during initialization of the tf_buffer. The constructor incorrectly received a node instance instead of a Duration. This should fix Issue #3 